### PR TITLE
Fix image visibility issues

### DIFF
--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -23,6 +23,7 @@ const eventCardStyles = makeStyles((theme) => ({
   media: {
     height: 0,
     paddingTop: '56.25%', // 16:9
+    visibility: 'visible',
   },
   expand: {
     transform: 'rotate(0deg)',

--- a/client/src/pages/Niche.tsx
+++ b/client/src/pages/Niche.tsx
@@ -15,6 +15,7 @@ const nicheStyles = makeStyles((theme) => ({
     marginTop: '5em',
     maxHeight: '30em',
     width: '50%',
+    visibility: 'visible',
     [theme.breakpoints.down('sm')]: {
       marginTop: '1em',
       width: '100%',


### PR DESCRIPTION
During production, certain images would have their visibility set to "hidden". In order to fix this issue, each image must have their CSS visibility property set to "visible". This issue does not happen during development.